### PR TITLE
App Pool: Start/Stop/Start Mode

### DIFF
--- a/iis/applicationpools/get.go
+++ b/iis/applicationpools/get.go
@@ -12,6 +12,7 @@ type getAppPool struct {
 	Cpu                   getAppPoolCpuLimits `json:"cpu"`
 	AutoStart             bool                `json:"autoStart"`
 	StartMode             string              `json:"startMode"`
+	State                 string              `json:"state"`
 }
 
 type getAppPoolCpuLimits struct {
@@ -45,6 +46,7 @@ Get-ItemProperty -Path "IIS:\AppPools\%s" | Select-Object | ConvertTo-Json
 		MaxCPUPerInterval: appPool.Cpu.Limit,
 		AutoStart:         appPool.AutoStart,
 		StartMode:         StartMode(appPool.StartMode),
+		State:             State(appPool.State),
 	}
 	return &pool, nil
 }

--- a/iis/applicationpools/get.go
+++ b/iis/applicationpools/get.go
@@ -10,6 +10,8 @@ type getAppPool struct {
 	ManagedPipelineMode   string              `json:"managedPipelineMode"`
 	ManagedRuntimeVersion string              `json:"managedRuntimeVersion"`
 	Cpu                   getAppPoolCpuLimits `json:"cpu"`
+	AutoStart             bool                `json:"autoStart"`
+	StartMode             string              `json:"startMode"`
 }
 
 type getAppPoolCpuLimits struct {
@@ -41,6 +43,8 @@ Get-ItemProperty -Path "IIS:\AppPools\%s" | Select-Object | ConvertTo-Json
 		Name:              appPool.Name,
 		FrameworkVersion:  ManagedFrameworkVersion(appPool.ManagedRuntimeVersion),
 		MaxCPUPerInterval: appPool.Cpu.Limit,
+		AutoStart:         appPool.AutoStart,
+		StartMode:         StartMode(appPool.StartMode),
 	}
 	return &pool, nil
 }

--- a/iis/applicationpools/lifecycle_test.go
+++ b/iis/applicationpools/lifecycle_test.go
@@ -28,6 +28,16 @@ func TestApplicationPoolLifecycle(t *testing.T) {
 		return
 	}
 
+	err = client.Stop(name)
+	if err != nil {
+		t.Fatalf("Error stopping Application Pool %q: %+v", name, err)
+	}
+
+	err = client.Start(name)
+	if err != nil {
+		t.Fatalf("Error starting Application Pool %q: %+v", name, err)
+	}
+
 	err = client.Delete(name)
 	if err != nil {
 		t.Fatalf("Error deleting App Pool %q: %+v", name, err)

--- a/iis/applicationpools/lifecycle_test.go
+++ b/iis/applicationpools/lifecycle_test.go
@@ -41,6 +41,10 @@ func TestApplicationPoolLifecycle(t *testing.T) {
 		t.Fatalf("Expected the App Pool %q to be OnDemand but it wasn't", name)
 	}
 
+	if pool.State != StateStarted {
+		t.Fatalf("Expected the App Pool %q State to be Started but it wasn't", name)
+	}
+
 	err = client.SetStartMode(name, false, StartModeAlwaysRunning)
 	if err != nil {
 		t.Fatalf("Error setting StartMode for Application Pool %q: %+v", name, err)
@@ -64,9 +68,27 @@ func TestApplicationPoolLifecycle(t *testing.T) {
 		t.Fatalf("Error stopping Application Pool %q: %+v", name, err)
 	}
 
+	pool, err = client.Get(name)
+	if err != nil {
+		t.Fatalf("Error retrieving Application Pool %q: %+v", name, err)
+	}
+
+	if pool.State != StateStopped {
+		t.Fatalf("Expected the App Pool %q State to be Stopped but it wasn't", name)
+	}
+
 	err = client.Start(name)
 	if err != nil {
 		t.Fatalf("Error starting Application Pool %q: %+v", name, err)
+	}
+
+	pool, err = client.Get(name)
+	if err != nil {
+		t.Fatalf("Error retrieving Application Pool %q: %+v", name, err)
+	}
+
+	if pool.State != StateStarted {
+		t.Fatalf("Expected the App Pool %q State to be Started but it wasn't", name)
 	}
 
 	err = client.Delete(name)

--- a/iis/applicationpools/lifecycle_test.go
+++ b/iis/applicationpools/lifecycle_test.go
@@ -28,6 +28,37 @@ func TestApplicationPoolLifecycle(t *testing.T) {
 		return
 	}
 
+	pool, err := client.Get(name)
+	if err != nil {
+		t.Fatalf("Error retrieving Application Pool %q: %+v", name, err)
+	}
+
+	if !pool.AutoStart {
+		t.Fatalf("Expected the App Pool %q to be enabled by default but it wasn't", name)
+	}
+
+	if pool.StartMode != StartModeOnDemand {
+		t.Fatalf("Expected the App Pool %q to be OnDemand but it wasn't", name)
+	}
+
+	err = client.SetStartMode(name, false, StartModeAlwaysRunning)
+	if err != nil {
+		t.Fatalf("Error setting StartMode for Application Pool %q: %+v", name, err)
+	}
+
+	pool, err = client.Get(name)
+	if err != nil {
+		t.Fatalf("Error retrieving Application Pool %q: %+v", name, err)
+	}
+
+	if pool.AutoStart {
+		t.Fatalf("Expected the App Pool %q to be disabled but it wasn't", name)
+	}
+
+	if pool.StartMode != StartModeAlwaysRunning {
+		t.Fatalf("Expected the App Pool %q to be AlwaysRunning but it wasn't", name)
+	}
+
 	err = client.Stop(name)
 	if err != nil {
 		t.Fatalf("Error stopping Application Pool %q: %+v", name, err)

--- a/iis/applicationpools/model.go
+++ b/iis/applicationpools/model.go
@@ -6,6 +6,8 @@ type ApplicationPool struct {
 	FrameworkVersion ManagedFrameworkVersion
 	// MaxCPUPerInterval is the amount of (1/1000's) of % CPU allocated per interval (5s)
 	MaxCPUPerInterval int64
+	AutoStart         bool
+	StartMode         StartMode
 }
 
 // ManagedFrameworkVersion is the version of the .net Framework used in the Application Pool
@@ -15,4 +17,11 @@ const (
 	ManagedFrameworkVersionFour ManagedFrameworkVersion = "v4.0"
 	ManagedFrameworkVersionTwo  ManagedFrameworkVersion = "v2.0"
 	ManagedFrameworkVersionNone ManagedFrameworkVersion = ""
+)
+
+type StartMode string
+
+const (
+	StartModeAlwaysRunning StartMode = "AlwaysRunning"
+	StartModeOnDemand      StartMode = "OnDemand"
 )

--- a/iis/applicationpools/model.go
+++ b/iis/applicationpools/model.go
@@ -8,6 +8,7 @@ type ApplicationPool struct {
 	MaxCPUPerInterval int64
 	AutoStart         bool
 	StartMode         StartMode
+	State             State
 }
 
 // ManagedFrameworkVersion is the version of the .net Framework used in the Application Pool
@@ -19,9 +20,18 @@ const (
 	ManagedFrameworkVersionNone ManagedFrameworkVersion = ""
 )
 
+// StartMode is the start mode for the Application Pool
 type StartMode string
 
 const (
 	StartModeAlwaysRunning StartMode = "AlwaysRunning"
 	StartModeOnDemand      StartMode = "OnDemand"
+)
+
+// State returns the current running state of the Application Pool
+type State string
+
+const (
+	StateStarted State = "Started"
+	StateStopped State = "Stopped"
 )

--- a/iis/applicationpools/start.go
+++ b/iis/applicationpools/start.go
@@ -1,0 +1,28 @@
+package applicationpools
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Start will start an Application Pool within IIS.
+func (c *AppPoolsClient) Start(name string) error {
+	commands := fmt.Sprintf(`
+Import-Module WebAdministration
+Start-WebAppPool -Name %q
+  `, name)
+
+	_, stderr, err := c.Run(commands)
+	if err != nil {
+		return fmt.Errorf("Error starting App Pool %q: %+v", name, err)
+	}
+
+	if serr := stderr; serr != nil {
+		v := strings.TrimSpace(*serr)
+		if v != "" {
+			return fmt.Errorf("Error starting App Pool %q: %s", name, v)
+		}
+	}
+
+	return nil
+}

--- a/iis/applicationpools/start_mode.go
+++ b/iis/applicationpools/start_mode.go
@@ -1,0 +1,32 @@
+package applicationpools
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// SetStartMode will set the Start Mode for an Application Pool within IIS.
+func (c *AppPoolsClient) SetStartMode(name string, autoStart bool, mode StartMode) error {
+	commands := fmt.Sprintf(`
+Import-Module WebAdministration
+$AppPool = Get-Item "IIS:\AppPools\%s"
+$AppPool.autoStart = "%s"
+$AppPool.startMode = "%s"
+$AppPool | Set-Item
+  `, name, strconv.FormatBool(autoStart), string(mode))
+
+	_, stderr, err := c.Run(commands)
+	if err != nil {
+		return fmt.Errorf("Error configuring the Start Mode for App Pool %q: %+v", name, err)
+	}
+
+	if serr := stderr; serr != nil {
+		v := strings.TrimSpace(*serr)
+		if v != "" {
+			return fmt.Errorf("Error configuring the Start Mode for App Pool %q: %s", name, v)
+		}
+	}
+
+	return nil
+}

--- a/iis/applicationpools/stop.go
+++ b/iis/applicationpools/stop.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-// Stop will start an Application Pool within IIS.
+// Stop will stop an Application Pool within IIS.
 func (c *AppPoolsClient) Stop(name string) error {
 	commands := fmt.Sprintf(`
 Import-Module WebAdministration

--- a/iis/applicationpools/stop.go
+++ b/iis/applicationpools/stop.go
@@ -1,0 +1,28 @@
+package applicationpools
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Stop will start an Application Pool within IIS.
+func (c *AppPoolsClient) Stop(name string) error {
+	commands := fmt.Sprintf(`
+Import-Module WebAdministration
+Stop-WebAppPool -Name %q
+  `, name)
+
+	_, stderr, err := c.Run(commands)
+	if err != nil {
+		return fmt.Errorf("Error stopping App Pool %q: %+v", name, err)
+	}
+
+	if serr := stderr; serr != nil {
+		v := strings.TrimSpace(*serr)
+		if v != "" {
+			return fmt.Errorf("Error stopping App Pool %q: %s", name, v)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
```
$ go test -v  .
=== RUN   TestCPULimits
--- PASS: TestCPULimits (5.97s)
=== RUN   TestAppPoolExists
--- PASS: TestAppPoolExists (2.60s)
=== RUN   TestAppPoolDoesNotExist
--- PASS: TestAppPoolDoesNotExist (0.99s)
=== RUN   TestApplicationPoolLifecycle
--- PASS: TestApplicationPoolLifecycle (7.33s)
=== RUN   TestRuntimeVersion
2018/11/08 15:03:11 Setting the Managed Runtime Version to ""..
2018/11/08 15:03:13 Setting the Managed Runtime Version to "v2.0"..
2018/11/08 15:03:15 Setting the Managed Runtime Version to "v4.0"..
--- PASS: TestRuntimeVersion (6.89s)
PASS
ok      github.com/tombuildsstuff/golang-iis/iis/applicationpools       23.882s
```
