### PR TITLE
App Pool: support for retrieving the PID

### DIFF
--- a/iis/applicationpools/process_id.go
+++ b/iis/applicationpools/process_id.go
@@ -1,0 +1,55 @@
+package applicationpools
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// GetWorkerProcessID returns the ID of the Worker Process used for this App Pool
+// this will only return the ProcessID for an App Pool with an associated Website
+// in the running state
+func (c *AppPoolsClient) GetWorkerProcessID(name string) (*[]int, error) {
+	commands := fmt.Sprintf(`
+Import-Module WebAdministration
+$pids = dir "IIS:\AppPools\%s\WorkerProcesses" | Select-Object -expand processId | ConvertTo-Json
+
+if ($pids.Count -eq 0) {
+    Write-Host "[]"
+} else {
+    if ($pids.Count -gt 1) {
+      $v = $pids | ConvertTo-Json
+	    Write-Host $v
+    } else {
+       $v = "[""{0}""]" -f $pids[0].ToString()
+        Write-Host $v
+    }
+}
+  `, name)
+
+	stdout, _, err := c.Run(commands)
+	if err != nil {
+		return nil, fmt.Errorf("Error retrieving Worker Process ID's for App Pool %q: %+v", name, err)
+	}
+
+	var processIds []string
+	if out := stdout; out != nil && *out != "" {
+		v := *out
+		err := json.Unmarshal([]byte(v), &processIds)
+		if err != nil {
+			return nil, fmt.Errorf("Error unmarshalling Worker Process ID's for App Pool %q: %+v", name, err)
+		}
+	}
+
+	var actualProcessIds []int
+	for _, v := range processIds {
+		i, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing %q as an int: %+v", v, err)
+		}
+
+		actualProcessIds = append(actualProcessIds, i)
+	}
+
+	return &actualProcessIds, nil
+}

--- a/iis/websites/app_setting_test.go
+++ b/iis/websites/app_setting_test.go
@@ -28,15 +28,11 @@ func TestAppSetting(t *testing.T) {
 		return
 	}
 
-	defer appPoolsClient.Delete(appPoolName)
-
 	err = websitesClient.Create(websiteName, appPoolName, defaultWebsitePath)
 	if err != nil {
 		t.Fatalf("Error creating Website %q in App Pool %q: %+v", websiteName, appPoolName, err)
 		return
 	}
-
-	defer websitesClient.Delete(websiteName)
 
 	exists, err := websitesClient.Exists(websiteName)
 	if err != nil {
@@ -68,4 +64,7 @@ func TestAppSetting(t *testing.T) {
 			return
 		}
 	}
+
+	websitesClient.Delete(websiteName)
+	appPoolsClient.Delete(appPoolName)
 }

--- a/iis/websites/authentication_mode_test.go
+++ b/iis/websites/authentication_mode_test.go
@@ -28,15 +28,11 @@ func TestAuthenticationMethod(t *testing.T) {
 		return
 	}
 
-	defer appPoolsClient.Delete(appPoolName)
-
 	err = websitesClient.Create(websiteName, appPoolName, defaultWebsitePath)
 	if err != nil {
 		t.Fatalf("Error creating Website %q in App Pool %q: %+v", websiteName, appPoolName, err)
 		return
 	}
-
-	defer websitesClient.Delete(websiteName)
 
 	// TODO: switch over to Exists when it exists
 	_, err = websitesClient.Get(websiteName)
@@ -72,4 +68,7 @@ func TestAuthenticationMethod(t *testing.T) {
 			return
 		}
 	}
+
+	websitesClient.Delete(websiteName)
+	appPoolsClient.Delete(appPoolName)
 }

--- a/iis/websites/connection_string_test.go
+++ b/iis/websites/connection_string_test.go
@@ -28,15 +28,11 @@ func TestConnectionString(t *testing.T) {
 		return
 	}
 
-	defer appPoolsClient.Delete(appPoolName)
-
 	err = websitesClient.Create(websiteName, appPoolName, defaultWebsitePath)
 	if err != nil {
 		t.Fatalf("Error creating Website %q in App Pool %q: %+v", websiteName, appPoolName, err)
 		return
 	}
-
-	defer websitesClient.Delete(websiteName)
 
 	exists, err := websitesClient.Exists(websiteName)
 	if err != nil {
@@ -68,4 +64,7 @@ func TestConnectionString(t *testing.T) {
 			return
 		}
 	}
+
+	websitesClient.Delete(websiteName)
+	appPoolsClient.Delete(appPoolName)
 }

--- a/iis/websites/exists_test.go
+++ b/iis/websites/exists_test.go
@@ -27,15 +27,11 @@ func TestWebsiteExists(t *testing.T) {
 		return
 	}
 
-	defer appPoolsClient.Delete(applicationPoolName)
-
 	err = websiteClient.Create(websiteName, applicationPoolName, defaultWebsitePath)
 	if err != nil {
 		t.Fatalf("Error creating Website %q in App Pool %q: %+v", websiteName, applicationPoolName, err)
 		return
 	}
-
-	defer websiteClient.Delete(websiteName)
 
 	exists, err := websiteClient.Exists(websiteName)
 	if err != nil {
@@ -47,6 +43,9 @@ func TestWebsiteExists(t *testing.T) {
 		t.Fatalf("Expected the Website %q to exist, but it didn't..", websiteName)
 		return
 	}
+
+	websiteClient.Delete(websiteName)
+	appPoolsClient.Delete(applicationPoolName)
 }
 
 func TestWebsiteDoesNotExist(t *testing.T) {

--- a/iis/websites/log_directory_test.go
+++ b/iis/websites/log_directory_test.go
@@ -28,15 +28,11 @@ func TestLogDirectory(t *testing.T) {
 		return
 	}
 
-	defer appPoolsClient.Delete(appPoolName)
-
 	err = websitesClient.Create(websiteName, appPoolName, defaultWebsitePath)
 	if err != nil {
 		t.Fatalf("Error creating Website %q in App Pool %q: %+v", websiteName, appPoolName, err)
 		return
 	}
-
-	defer websitesClient.Delete(websiteName)
 
 	exists, err := websitesClient.Exists(websiteName)
 	if err != nil {
@@ -76,4 +72,7 @@ func TestLogDirectory(t *testing.T) {
 		t.Fatalf("Expected the updated Log Directory to be %q but was %q", updatedPath, *path)
 		return
 	}
+
+	websitesClient.Delete(websiteName)
+	appPoolsClient.Delete(appPoolName)
 }

--- a/iis/websites/network_limits_test.go
+++ b/iis/websites/network_limits_test.go
@@ -27,15 +27,11 @@ func TestNetworkLimits(t *testing.T) {
 		return
 	}
 
-	defer appPoolsClient.Delete(appPoolName)
-
 	err = websitesClient.Create(websiteName, appPoolName, defaultWebsitePath)
 	if err != nil {
 		t.Fatalf("Error creating Website %q in App Pool %q: %+v", websiteName, appPoolName, err)
 		return
 	}
-
-	defer websitesClient.Delete(websiteName)
 
 	site, err := websitesClient.Get(websiteName)
 	if err != nil {
@@ -81,4 +77,7 @@ func TestNetworkLimits(t *testing.T) {
 		t.Fatalf("Expected the default Max Bandwidth to be %d but got %d", defaultNetworkLimit, site.MaxBandwidthPerSecondInBytes)
 		return
 	}
+
+	websitesClient.Delete(websiteName)
+	appPoolsClient.Delete(appPoolName)
 }


### PR DESCRIPTION
This PR adds support for retrieving the PID of a running App Service.

Note: this can only be obtained for an App Service with a Website attached in the Running state

```
$ go test -v .
=== RUN   TestAppSetting
--- PASS: TestAppSetting (10.06s)
=== RUN   TestAuthenticationMethod
2018/11/08 20:32:48 Setting Authentication Mode to "None"..
2018/11/08 20:32:50 Setting Authentication Mode to "Federated"..
2018/11/08 20:32:52 Setting Authentication Mode to "Forms"..
2018/11/08 20:32:53 Setting Authentication Mode to "Passport"..
2018/11/08 20:32:55 Setting Authentication Mode to "Windows"..
--- PASS: TestAuthenticationMethod (12.68s)
=== RUN   TestConnectionString
--- PASS: TestConnectionString (9.17s)
=== RUN   TestWebsiteExists
--- PASS: TestWebsiteExists (2.80s)
=== RUN   TestWebsiteDoesNotExist
--- PASS: TestWebsiteDoesNotExist (0.60s)
=== RUN   TestWebsiteLifecycle
--- PASS: TestWebsiteLifecycle (4.94s)
=== RUN   TestLogDirectory
--- PASS: TestLogDirectory (5.48s)
=== RUN   TestNetworkLimits
--- PASS: TestNetworkLimits (4.58s)
PASS
ok      github.com/tombuildsstuff/golang-iis/iis/websites       50.399s
```