### PR TITLE
Website: create function 'List' which allows all websites to be listed

### DIFF
--- a/iis/websites/list.go
+++ b/iis/websites/list.go
@@ -1,0 +1,45 @@
+package websites
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func (c WebsitesClient) List() ([]string, error) {
+	commands := `
+		Import-Module WebAdministration
+		Get-Website | select name | ConvertTo-Json -Compress
+  	`
+
+	stdout, _, err := c.Run(commands)
+	if err != nil {
+		return nil, fmt.Errorf("Error listing all Website: %+v", err)
+	}
+
+	var sitesJson = []map[string]string{}
+
+	if out := stdout; out != nil && *out != "" {
+		v := *out
+		err := json.Unmarshal([]byte(v), &sitesJson)
+
+		if err != nil {
+			// Powershell omits the outer array if the return count of sites == 1
+			// Hence we unmarshal a single map here
+
+			var singleSite = make(map[string]string)
+			err := json.Unmarshal([]byte(v), &singleSite)
+			sitesJson = append(sitesJson, singleSite)
+
+			if err != nil {
+				return nil, fmt.Errorf("Error unmarshalling Websites: %+v", err)
+			}
+		}
+	}
+
+	sites := []string{}
+	for _, i := range sitesJson {
+		sites = append(sites, i["name"])
+	}
+
+	return sites, nil
+}


### PR DESCRIPTION
This simple PR creates a new function 'List', that can be used to return a slice of string with the website names. Please let me know your thoughts or merge if it makes sense.

There's a little bit of complication due to the nature of how powershell encodes the results to json. If the result contains only 1 element (of type map[string]string in this case), then powershell will not enclose the element in the outer array, but it will if there > 1 elements.